### PR TITLE
Don't fail if UUID has multiple zeroes in it.

### DIFF
--- a/url62/url62.go
+++ b/url62/url62.go
@@ -48,18 +48,19 @@ func convertUp(oldNumber string, baseAlphabet string) (string, error) {
 	newNumber := make([]byte, 23) //converted size of max base-62 uuid
 	i := len(newNumber)
 
-	for n.Int64() != 0 {
+	zero := big.NewInt(0)
+	for n.Cmp(zero) != 0 {
 		i--
 		_, r := n.DivMod(n, base, big.NewInt(0))
 		newNumber[i] = baseAlphabet[r.Int64()]
 	}
-	return string(newNumber[i:]), nil
+	return fmt.Sprintf("%022s", newNumber[i:]), nil
 }
 
 func convertDown(oldNumber string, baseAlphabet string) (string, error) {
 	// Return if oldNumber is less or bigger than 22
 	if len(oldNumber) != 22 {
-		return "", errors.New("Not valid base62 string")
+		return "", errors.New("Not valid base62-encoded UUID string")
 	}
 
 	n := big.NewInt(0)
@@ -79,7 +80,7 @@ func convertDown(oldNumber string, baseAlphabet string) (string, error) {
 		n.Add(n, big.NewInt(int64(i)))
 	}
 
-	return fmt.Sprintf("%02x", n), nil
+	return fmt.Sprintf("%032x", n), nil
 }
 
 func insert(s string, sep string, i int) string {

--- a/url62/url62_test.go
+++ b/url62/url62_test.go
@@ -27,3 +27,16 @@ func Test_Wrong_ToUUID(t *testing.T) {
 		t.Error("Not valid")
 	}
 }
+
+func Test_ManyZeroes_UUID(t *testing.T) {
+	ref := "00000000-0000-4000-8000-000000000000"
+	u, err := FromUUID(ref)
+	if err != nil || u != "000000001vGeH72LxVtxKg" {
+		t.Error("Not valid")
+	}
+
+	d, err := ToUUID(u)
+	if err != nil || d != ref {
+		t.Error("Not valid")
+	}
+}


### PR DESCRIPTION
I've noticed that if UUID has 64 bits worth of trailing zeroes (for example, like `00000000-0000-4000-8000-000000000000`) - encoder would fail to handle it, returning an empty string (without any error).

Also, decoding UUID with leading zeroes may fail as well, as the hex encoding won't be left-padded to the correct length and dashes would go in the wrong positions.

This PR should fix those issues.